### PR TITLE
fix mend configuration file

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,3 @@
 {
-  "settingsInheritedFrom": "whitesource-config/whitesource-config@master"
+  "settingsInheritedFrom": "ibm-mend-config/mend-config@main"
 }


### PR DESCRIPTION
## Description

The .whitesource config file points to a non-existent repository currently. This PR fixes that issue. In another repo, I noticed the `ibm-mend-app` opened a [PR](https://github.com/IBM/openapi-to-graphql/pull/504/files) to inherit settings from "ibm-mend-config/mend-config@main", so I updated it to use that.

Fixes #2

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Afaik, not really possible to test without merging.

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas - N/A
- [ ] I have made corresponding changes to the documentation - N/A
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A
- [ ] New and existing unit tests pass locally with my changes - N/A